### PR TITLE
Improve Chrome startup resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ INSTAGRAM_USERNAME=your_username
 INSTAGRAM_PASSWORD=your_password
 INSTAGRAM_COMMENT=Nice photo!
 INSTAGRAM_PROFILE_URL=https://www.instagram.com/your_username/
+# Optional overrides:
+# CHROME_USER_DATA_DIR=/path/to/persistent/profile
+# CHROME_HEADLESS=false
 ```
 
 ### Running the automation
@@ -38,6 +41,14 @@ python instagram_comment.py            # Uses ./.env by default
 python instagram_comment.py custom.env  # Explicit env file path
 ```
 
-The script launches a headless Chrome browser, signs into Instagram, navigates
-to the supplied profile, opens the first post, and submits the configured
+By default the script launches Chrome headlessly while storing session data in
+`./.selenium-profile` so that the login can persist across runs. You can change
+this directory (or disable persistence entirely) via `CHROME_USER_DATA_DIR` and
+toggle headless mode with `CHROME_HEADLESS`. If Chrome refuses to boot (for
+example with the common `DevToolsActivePort` error) the script automatically
+retries with a visible browser and, if necessary, with a temporary profile while
+printing guidance to the terminal.
+
+During execution the script signs into Instagram if needed, navigates to the
+supplied profile, opens the first available post, and submits the configured
 comment.

--- a/instagram_comment.py
+++ b/instagram_comment.py
@@ -12,7 +12,12 @@ from pathlib import Path
 from typing import Dict
 
 from selenium import webdriver
-from selenium.common.exceptions import TimeoutException
+from selenium.common.exceptions import (
+    SessionNotCreatedException,
+    TimeoutException,
+    StaleElementReferenceException,
+    WebDriverException,
+)
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
@@ -23,6 +28,8 @@ ENV_USERNAME_KEY = "INSTAGRAM_USERNAME"
 ENV_PASSWORD_KEY = "INSTAGRAM_PASSWORD"
 ENV_COMMENT_KEY = "INSTAGRAM_COMMENT"
 ENV_PROFILE_KEY = "INSTAGRAM_PROFILE_URL"
+ENV_CHROME_PROFILE_DIR = "CHROME_USER_DATA_DIR"
+ENV_CHROME_HEADLESS = "CHROME_HEADLESS"
 
 
 class EnvConfigError(RuntimeError):
@@ -85,28 +92,127 @@ def get_required(values: Dict[str, str], key: str) -> str:
     return value
 
 
-def build_driver() -> webdriver.Chrome:
-    """Configure and return a headless Chrome WebDriver instance."""
+def get_optional(values: Dict[str, str], key: str) -> str | None:
+    """Return an optional environment variable value or ``None`` when missing."""
+
+    value = values.get(key)
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    return stripped
+
+
+def str_to_bool(value: str | None, *, default: bool = True) -> bool:
+    """Return the boolean interpretation of ``value``."""
+
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+def _create_chrome_options(*, headless: bool, user_data_dir: Path | None) -> Options:
+    """Return a configured ``Options`` instance for Chrome."""
 
     options = Options()
-    options.add_argument("--headless=new")
+    if headless:
+        options.add_argument("--headless=new")
     options.add_argument("--disable-gpu")
     options.add_argument("--window-size=1920,1080")
-    return webdriver.Chrome(options=options)
+    options.add_argument("--remote-debugging-port=0")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--no-sandbox")
+    if user_data_dir is not None:
+        options.add_argument(f"--user-data-dir={user_data_dir}")
+    return options
+
+
+def build_driver(
+    user_data_dir: Path | None = None,
+    *,
+    headless: bool = True,
+) -> webdriver.Chrome:
+    """Configure and return a Chrome WebDriver instance.
+
+    When Chrome fails to boot (commonly with ``DevToolsActivePort`` errors) the
+    driver is retried with progressively more permissive settings. This keeps
+    the automation usable on systems where headless mode or persistent
+    profiles are unstable without forcing users to pre-tune their
+    configuration.
+    """
+
+    attempts: list[tuple[bool, Path | None, str | None]] = [
+        (headless, user_data_dir, None),
+    ]
+
+    if headless:
+        attempts.append(
+            (
+                False,
+                user_data_dir,
+                "Chrome failed to start headless; retrying with a visible browser window.",
+            )
+        )
+
+    if user_data_dir is not None:
+        attempts.append(
+            (
+                False,
+                None,
+                "Chrome failed to start with the persistent profile; retrying without it.",
+            )
+        )
+
+    last_error: SessionNotCreatedException | None = None
+    for headless_attempt, profile_dir, message in attempts:
+        options = _create_chrome_options(
+            headless=headless_attempt, user_data_dir=profile_dir
+        )
+        try:
+            return webdriver.Chrome(options=options)
+        except SessionNotCreatedException as exc:
+            last_error = exc
+            error_message = exc.msg or ""
+            if "DevToolsActivePort" not in error_message and "crashed" not in error_message:
+                raise
+            if message:
+                print(message, file=sys.stderr)
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("Chrome driver failed to start for an unknown reason")
 
 
 def login(driver: webdriver.Chrome, username: str, password: str) -> None:
     """Log into Instagram with the provided credentials."""
 
-    driver.get("https://www.instagram.com/accounts/login/")
+    login_url = "https://www.instagram.com/accounts/login/"
+    driver.get(login_url)
     wait = WebDriverWait(driver, 20)
 
-    username_field = wait.until(
-        EC.presence_of_element_located((By.NAME, "username"))
-    )
-    password_field = wait.until(
-        EC.presence_of_element_located((By.NAME, "password"))
-    )
+    def _login_page_loaded(driver: webdriver.Chrome) -> bool:
+        return (
+            "accounts/login" not in driver.current_url
+            or driver.find_elements(By.NAME, "username")
+        )
+
+    wait.until(_login_page_loaded)
+
+    if "accounts/login" not in driver.current_url:
+        wait.until(
+            EC.presence_of_element_located(
+                (By.XPATH, "//a[contains(@href, '/explore/')]")
+            )
+        )
+        return
+
+    username_field = driver.find_element(By.NAME, "username")
+    password_field = driver.find_element(By.NAME, "password")
 
     username_field.clear()
     username_field.send_keys(username)
@@ -125,12 +231,39 @@ def navigate_to_first_post(driver: webdriver.Chrome, profile_url: str) -> None:
     driver.get(profile_url)
     wait = WebDriverWait(driver, 20)
 
-    wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, "article")))
-    post_links = driver.find_elements(By.CSS_SELECTOR, "article a[href*='/p/']")
-    if not post_links:
-        raise RuntimeError("Could not locate any posts on the profile page")
+    wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, "main")))
+    click_wait = WebDriverWait(driver, 5)
 
-    post_links[0].click()
+    post_selectors = [
+        "article a[href*='/p/']",
+        "main section a[href*='/p/']",
+        "main div[role='presentation'] a[href*='/p/']",
+    ]
+
+    for _ in range(10):
+        for selector in post_selectors:
+            post_links = driver.find_elements(By.CSS_SELECTOR, selector)
+            if post_links:
+                first_post = post_links[0]
+                driver.execute_script(
+                    "arguments[0].scrollIntoView({block: 'center'});", first_post
+                )
+                try:
+                    click_wait.until(
+                        lambda d, element=first_post: all(
+                            (element.is_displayed(), element.is_enabled())
+                        )
+                    )
+                    first_post.click()
+                    return
+                except (StaleElementReferenceException, TimeoutException):
+                    continue
+                except WebDriverException:
+                    continue
+        driver.execute_script("window.scrollBy(0, 400)")
+        time.sleep(0.5)
+
+    raise RuntimeError("Could not locate any posts on the profile page")
 
 
 def leave_comment(driver: webdriver.Chrome, comment: str) -> None:
@@ -155,17 +288,29 @@ def main(argv: list[str] | None = None) -> int:
     argv = argv or sys.argv[1:]
     env_path = Path(argv[0]) if argv else Path(".env")
 
+    user_data_dir: Path | None = None
     try:
         env_values = load_env(env_path)
         username = get_required(env_values, ENV_USERNAME_KEY)
         password = get_required(env_values, ENV_PASSWORD_KEY)
         comment = get_required(env_values, ENV_COMMENT_KEY)
         profile_url = get_required(env_values, ENV_PROFILE_KEY)
+        headless = str_to_bool(get_optional(env_values, ENV_CHROME_HEADLESS), default=True)
+        profile_dir_value = get_optional(env_values, ENV_CHROME_PROFILE_DIR)
+        if profile_dir_value and profile_dir_value.strip().lower() in {
+            "none",
+            "disable",
+            "disabled",
+        }:
+            user_data_dir = None
+        else:
+            user_data_dir = Path(profile_dir_value or ".selenium-profile").expanduser()
+            user_data_dir.mkdir(parents=True, exist_ok=True)
     except (FileNotFoundError, EnvConfigError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 
-    driver = build_driver()
+    driver = build_driver(user_data_dir=user_data_dir, headless=headless)
     try:
         login(driver, username, password)
         navigate_to_first_post(driver, profile_url)


### PR DESCRIPTION
## Summary
- retry Chrome driver start-up with progressively less restrictive settings when DevToolsActivePort crashes occur
- add common stability flags to the Chrome options helper while keeping persistent profiles configurable
- document the automatic fallback behaviour for users in the README

## Testing
- python -m compileall instagram_comment.py

------
https://chatgpt.com/codex/tasks/task_e_68d1c5206cb8832d9fd6eb8c3fdf260b